### PR TITLE
Redact the values of some columns before syncing to bq binlogs

### DIFF
--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellBigQueryProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellBigQueryProducer.java
@@ -220,11 +220,13 @@ class MaxwellBigQueryProducerWorker extends AbstractAsyncProducer implements Run
   private static final List<String> CLEARED_COLUMNS;
 
   static {
-    CLEARED_COLUMNS = List.of(
-      "dp_test.test_index_created.created_at",
-      "dp_test.test_index_created.updated_at",
-      "dp_test.test_index_both.created_at"
-    );
+    String envValue = System.getenv("cleared_columns");
+    if (envValue != null && !envValue.isEmpty()) {
+      String cleaned = envValue.replaceAll("\\s+", "");
+      CLEARED_COLUMNS = List.of(cleaned.split(","));
+    } else {
+      CLEARED_COLUMNS = List.of();
+    }
 
     Map<String, Map<String, Map<String, String>>> actions = new HashMap<>();
     // Format: database.table.column

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellBigQueryProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellBigQueryProducer.java
@@ -30,7 +30,10 @@ import io.grpc.Status;
 import io.grpc.Status.Code;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -213,6 +216,33 @@ class MaxwellBigQueryProducerWorker extends AbstractAsyncProducer implements Run
   // checked approximately, leave a buffer
   public static final long MAX_MESSAGE_SIZE_BYTES = 5_000_000;
 
+  private static final Map<String, Map<String, Map<String, String>>> COLUMN_ACTIONS;
+  private static final List<String> CLEARED_COLUMNS;
+
+  static {
+    CLEARED_COLUMNS = List.of(
+      "dp_test.test_index_created.created_at",
+      "dp_test.test_index_created.updated_at",
+      "dp_test.test_index_both.created_at"
+    );
+
+    Map<String, Map<String, Map<String, String>>> actions = new HashMap<>();
+    // Format: database.table.column
+    for (String columnPath : CLEARED_COLUMNS) {
+      String[] parts = columnPath.split("\\.", 3);
+      if (parts.length != 3) {
+        LOGGER.warn("Skipping invalid cleared column entry: {}", columnPath);
+        continue;
+      }
+      actions
+        .computeIfAbsent(parts[0], db -> new HashMap<>())
+        .computeIfAbsent(parts[1], table -> new HashMap<>())
+        .put(parts[2], "clear");
+    }
+
+    COLUMN_ACTIONS = Collections.unmodifiableMap(actions);
+  }
+
 
 
   private final ArrayBlockingQueue<RowMap> queue;
@@ -313,6 +343,7 @@ class MaxwellBigQueryProducerWorker extends AbstractAsyncProducer implements Run
   public void sendAsync(RowMap r, CallbackCompleter cc) throws Exception {
 
     JSONObject record = new JSONObject(r.toJSON(outputConfig));
+    applyColumnActions(r, record);
     covertJSONObjectFieldsToString(record);
 
     int recordSize = AppendContext.getJsonByteSize(record);
@@ -372,6 +403,38 @@ class MaxwellBigQueryProducerWorker extends AbstractAsyncProducer implements Run
         e.printStackTrace();
       }
     }, 1, TimeUnit.MINUTES); // 1 minute delay
+  }
+
+  private void applyColumnActions(RowMap row, JSONObject record) {
+    if (COLUMN_ACTIONS.isEmpty()) {
+      return;
+    }
+
+    Map<String, Map<String, String>> databaseConfig = COLUMN_ACTIONS.get(row.getDatabase());
+    if (databaseConfig == null) {
+      return;
+    }
+
+    Map<String, String> tableConfig = databaseConfig.get(row.getTable());
+    if (tableConfig == null || tableConfig.isEmpty()) {
+      return;
+    }
+
+    applyColumnActionsToObject(record.opt("data"), tableConfig);
+    applyColumnActionsToObject(record.opt("old"), tableConfig);
+  }
+
+  private void applyColumnActionsToObject(Object obj, Map<String, String> tableConfig) {
+    if (!(obj instanceof JSONObject)) {
+      return;
+    }
+
+    JSONObject target = (JSONObject) obj;
+    for (Map.Entry<String, String> entry : tableConfig.entrySet()) {
+      if ("clear".equalsIgnoreCase(entry.getValue()) && target.has(entry.getKey())) {
+        target.put(entry.getKey(), JSONObject.NULL);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the contents of data streamed to BigQuery by nulling specific columns, which can impact downstream consumers and data correctness if the configuration is wrong or incomplete.
> 
> **Overview**
> Adds a hardcoded column-action map in `MaxwellBigQueryProducerWorker` to *redact/clear* specific `database.table.column` fields by setting them to `null`.
> 
> The producer now applies these actions to both `data` and `old` payload sections before converting the row to strings and batching/sending it to BigQuery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 698ff86a280de1956f31d212352ee1d94b76efca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->